### PR TITLE
update @reach/router version

### DIFF
--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "@reach/router": "^1.1.1",
+    "@reach/router": "^1.2.1",
     "gatsby": "^2.0.0",
     "react": "^16.4.2",
     "react-dom": "^16.4.2"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Update **Gatsby Link**'s dependency `@reach/router` version to `1.2.1`.

To fix escape href before check current.

## Related Issues

Fixes #18597
